### PR TITLE
EIT-2090 | Review PHP SDK to align it with the JS SDK

### DIFF
--- a/lib/Anchor/Repository/AnchorRepository.php
+++ b/lib/Anchor/Repository/AnchorRepository.php
@@ -20,10 +20,18 @@ final class AnchorRepository implements IAnchorRepository
         $this->configService = $configService;
     }
 
-    public function getAnchor(int $anchor): AnchorRetrieveResponse
+    public function getAnchor(int $anchor): Anchor
     {
         $url = $this->getConfigService()->getApiBaseUrl() . "/core/anchor/" . $anchor;
-        return new AnchorRetrieveResponse($this->getHttpClient()->get($url));
+        $response = new AnchorRetrieveResponse($this->getHttpClient()->get($url));
+        $anchor = new Anchor(
+            $response->anchorId,
+            $response->blockRoots,
+            $response->networks,
+            $response->root,
+            $response->status
+        );
+        return $anchor;
     }
 
     private function getHttpClient(): HttpClient

--- a/lib/Anchor/Repository/IAnchorRepository.php
+++ b/lib/Anchor/Repository/IAnchorRepository.php
@@ -3,9 +3,8 @@
 namespace Bloock\Anchor\Repository;
 
 use Bloock\Anchor\Entity\Anchor;
-use Bloock\Anchor\Entity\Dto\AnchorRetrieveResponse;
 
 interface IAnchorRepository
 {
-    public function getAnchor(int $anchor): AnchorRetrieveResponse;
+    public function getAnchor(int $anchor): Anchor;
 }

--- a/lib/Anchor/Service/AnchorService.php
+++ b/lib/Anchor/Service/AnchorService.php
@@ -34,8 +34,7 @@ final class AnchorService implements IAnchorService
             throw new InvalidArgumentException();
         }
 
-        $response = $this->getAnchorRepository()->getAnchor($id);
-        $anchor = new Anchor($response->anchorId, $response->blockRoots, $response->networks, $response->root, $response->status);
+        $anchor = $this->getAnchorRepository()->getAnchor($id);
         if ($anchor == null) {
             throw new AnchorNotFoundException();
         }

--- a/lib/BloockClient.php
+++ b/lib/BloockClient.php
@@ -137,7 +137,7 @@ final class BloockClient
     }
 
     /**
-     * Checks if the integrity Proof is currently included in the blockchain.
+     * Validates if the root is currently included in the blockchain.
      * 
      * @param  Record An integrity Proof's root Record.
      * @param  string blockchain network where the records will be validated.
@@ -150,11 +150,11 @@ final class BloockClient
     }
 
     /**
-     * It retrieves a proof for the specified list of Anchor using getProof, verifies it using verifyProof and checks if it's included in blockchain with validateRoot.
+     * It retrieves a proof for the specified list of Anchor using getProof and verifies it using verifyProof and validateRoot.
      *
      * @param  mixed List of records to validate
      * @param string|null Optional network to verify from. 
-     * @return Record The integrity proof's root Record
+     * @return int A number representing the timestamp in milliseconds when the anchor was registered in Blockchain
      * @throws InvalidArgumentException Informs that the input is empty.
      * @throws HttpRequestException Error return by Bloock's API.
      * @throws ProofNotFoundException Proof not found.

--- a/lib/Proof/Repository/IProofRepository.php
+++ b/lib/Proof/Repository/IProofRepository.php
@@ -8,7 +8,7 @@ use Bloock\Record\Entity\Record;
 
 interface IProofRepository
 {
-    public function retrieveProof(array $records): ProofRetrieveResponse;
+    public function retrieveProof(array $records): Proof;
     public function verifyProof(Proof $proof): Record;
     public function validateRoot(string $network, Record $root): int;
 }

--- a/lib/Proof/Repository/ProofRepository.php
+++ b/lib/Proof/Repository/ProofRepository.php
@@ -2,6 +2,7 @@
 
 namespace Bloock\Proof\Repository;
 
+use Bloock\Anchor\Entity\Anchor;
 use Bloock\Config\Service\ConfigService;
 use Bloock\Config\Service\IConfigService;
 use Bloock\Infrastructure\Blockchain;
@@ -45,7 +46,6 @@ final class ProofRepository implements IProofRepository
             $response->nodes,
             $response->depth,
             $response->bitmap,
-            $response->root,
             $anchor
         );
     }

--- a/lib/Proof/Repository/ProofRepository.php
+++ b/lib/Proof/Repository/ProofRepository.php
@@ -26,11 +26,28 @@ final class ProofRepository implements IProofRepository
         $this->configService = $configService;
     }
 
-    public function retrieveProof(array $records): ProofRetrieveResponse
+    public function retrieveProof(array $records): Proof
     {
         $url = $this->getConfigService()->getApiBaseUrl() . "/core/proof";
         $body = new ProofRetrieveRequest($records);
-        return new ProofRetrieveResponse($this->getHttpClient()->post($url, $body));
+        $response = new ProofRetrieveResponse($this->getHttpClient()->post($url, $body));
+
+        $anchor = new Anchor(
+            $response->anchor['anchor_id'],
+            $response->anchor['blockRoots'] ?? [],
+            $response->anchor['networks'],
+            $response->anchor['root'],
+            $response->anchor['status']
+        );
+
+        return new Proof(
+            $response->leaves,
+            $response->nodes,
+            $response->depth,
+            $response->bitmap,
+            $response->root,
+            $anchor
+        );
     }
 
     public function verifyProof(Proof $proof): Record

--- a/lib/Proof/Service/ProofService.php
+++ b/lib/Proof/Service/ProofService.php
@@ -43,23 +43,7 @@ final class ProofService implements IProofService
 
         $sorted = Record::sort($records);
 
-        $response =  $this->getProofRepository()->retrieveProof($sorted);
-
-        $anchor = new Anchor(
-            $response->anchor['anchor_id'],
-            $response->anchor['blockRoots'] ?? [],
-            $response->anchor['networks'],
-            $response->anchor['root'],
-            $response->anchor['status']
-        );
-
-        $proof = new Proof(
-            $response->leaves,
-            $response->nodes,
-            $response->depth,
-            $response->bitmap,
-            $anchor
-        );
+        $proof =  $this->getProofRepository()->retrieveProof($sorted);
 
         if (count($sorted) == 1) {
             $sorted[0]->setProof($proof);

--- a/tests/unit/Anchor/AnchorRepositoryTest.php
+++ b/tests/unit/Anchor/AnchorRepositoryTest.php
@@ -41,11 +41,11 @@ final class AnchorRepositoryTest extends TestCase
         $this->configServiceMock->method('getApiBaseUrl')
             ->willReturn('api url');
 
-        $response = $this->anchorRepository->getAnchor(1);
-        $this->assertEquals(1, $response->anchorId);
-        $this->assertEquals(['block_root'], $response->blockRoots);
-        $this->assertEquals([], $response->networks);
-        $this->assertEquals('root', $response->root);
-        $this->assertEquals('Success', $response->status);
+        $anchor = $this->anchorRepository->getAnchor(1);
+        $this->assertEquals(1, $anchor->id);
+        $this->assertEquals(['block_root'], $anchor->blockRoots);
+        $this->assertEquals([], $anchor->networks);
+        $this->assertEquals('root', $anchor->root);
+        $this->assertEquals('Success', $anchor->status);
     }
 }

--- a/tests/unit/Anchor/AnchorServiceTest.php
+++ b/tests/unit/Anchor/AnchorServiceTest.php
@@ -37,13 +37,7 @@ final class AnchorServiceTest extends TestCase
     public function test_get_anchor_okay()
     {
         $this->anchorRepositoryMock->method('getAnchor')
-            ->willReturn(new AnchorRetrieveResponse(array(
-                'anchor_id' => 1,
-                'block_roots' => ['block_root'],
-                'networks' => [],
-                'root' => 'root',
-                'status' => 'Success'
-            )));
+            ->willReturn(new Anchor(1, ['block_root'], [], 'root', 'Success'));
 
         $response = $this->anchorService->getAnchor(1);
         $this->assertEquals(1, $response->id);
@@ -107,21 +101,9 @@ final class AnchorServiceTest extends TestCase
     {
         if ($this->counter < $this->maxCount) {
             $this->counter += 1;
-            return new AnchorRetrieveResponse(array(
-                'anchor_id' => 1,
-                'block_roots' => [],
-                'networks' => [],
-                'root' => 'root',
-                'status' => 'Pending'
-            ));
+            return new Anchor(1, [], [], 'root', 'Pending');
         }
 
-        return new AnchorRetrieveResponse(array(
-            'anchor_id' => 1,
-            'block_roots' => ['block_root'],
-            'networks' => [],
-            'root' => 'root',
-            'status' => 'Success'
-        ));
+        return new Anchor(1, ['block_root'], [], 'root', 'Success');
     }
 }

--- a/tests/unit/Proof/ProofServiceTest.php
+++ b/tests/unit/Proof/ProofServiceTest.php
@@ -4,10 +4,8 @@
 namespace Bloock\Tests;
 
 use Bloock\Anchor\Entity\Anchor;
-use Bloock\Anchor\Entity\Dto\AnchorRetrieveResponse;
 use Bloock\Proof\Service\IProofService;
 use Bloock\Proof\Service\ProofService;
-use Bloock\Proof\Entity\Dto\ProofRetrieveResponse;
 use Bloock\Proof\Entity\Dto\ProofWriteResponse;
 use Bloock\Proof\Entity\Exception\InvalidProofException;
 use Bloock\Proof\Entity\Proof;
@@ -33,23 +31,10 @@ final class ProofServiceTest extends TestCase
      */
     public function test_get_proofs_okay_from_string()
     {
-        $mockAnchor = array(
-            'anchor_id' => 1,
-            'blockRoots' => null,
-            'networks' => [''],
-            'block_roots' => [''], 
-            'root' => '',
-            'status' => 'pending');
+        $mockAnchor = new Anchor(1, [], [], 'c6372dab6a48637173a457e3ae0c54a500bb50346e847eccf2b818ade94d8ccf', 'pending');
+
         $this->proofRepositoryMock->method('retrieveProof')
-            ->willReturn(new ProofRetrieveResponse(array(
-                    'leaves' => ['leaf1'],
-                    'nodes' => ['node1'],
-                    'depth' => 'depth',
-                    'bitmap' => 'bitmap',
-                    'root' => 'root',
-                    'anchor' => $mockAnchor
-                )
-            ));       
+                ->willReturn(new Proof(['leaf1'], ['node1'], 'depth', 'bitmap', $mockAnchor));
         
         $records = array(Record::fromString('myrecord'));
         $response = $this->proofService->retrieveProof($records);
@@ -63,23 +48,10 @@ final class ProofServiceTest extends TestCase
      */
     public function test_get_proofs_okay_from_json_with_proof()
     {
-        $mockAnchor = array(
-            'anchor_id' => 1,
-            'blockRoots' => null,
-            'networks' => [''],
-            'block_roots' => [''], 
-            'root' => '',
-            'status' => 'pending');
+        $mockAnchor = new Anchor(1, [], [], 'c6372dab6a48637173a457e3ae0c54a500bb50346e847eccf2b818ade94d8ccf', 'pending');
+
         $this->proofRepositoryMock->method('retrieveProof')
-            ->willReturn(new ProofRetrieveResponse(array(
-                    'leaves' => ['leaf1'],
-                    'nodes' => ['node1'],
-                    'depth' => 'depth',
-                    'bitmap' => 'bitmap',
-                    'root' => 'root',
-                    'anchor' => $mockAnchor
-                )
-            ));
+                ->willReturn(new Proof(['leaf1'], ['node1'], 'depth', 'bitmap', $mockAnchor));
         $mockProof = new Proof(['leaf1'], ['node1'], 'depth', 'bitmap');
         
         $records = array(Record::fromJSON(array('hello' => 'world')));
@@ -95,23 +67,10 @@ final class ProofServiceTest extends TestCase
      */
     public function test_get_proofs_okay_from_json_without_proof()
     {
-        $mockAnchor = array(
-            'anchor_id' => 1,
-            'blockRoots' => null,
-            'networks' => [''],
-            'block_roots' => [''], 
-            'root' => '',
-            'status' => 'pending');
+        $mockAnchor = new Anchor(1, [], [], 'c6372dab6a48637173a457e3ae0c54a500bb50346e847eccf2b818ade94d8ccf', 'pending');
+
         $this->proofRepositoryMock->method('retrieveProof')
-            ->willReturn(new ProofRetrieveResponse(array(
-                    'leaves' => ['leaf1'],
-                    'nodes' => ['node1'],
-                    'depth' => 'depth',
-                    'bitmap' => 'bitmap',
-                    'root' => 'root',
-                    'anchor' => $mockAnchor
-                )
-            ));       
+                ->willReturn(new Proof(['leaf1'], ['node1'], 'depth', 'bitmap', $mockAnchor));      
         
         $records = array(Record::fromJSON(array('hello' => 'world')));
         $response = $this->proofService->retrieveProof($records);


### PR DESCRIPTION
The second and third commits can be reverted, if desired. But it makes sense that the repository returns a domain object (Proof, Anchor) instead of a dto (ProofResponse, AnchorResponse).
